### PR TITLE
Update to Prince 12.5

### DIFF
--- a/Formula/prince.rb
+++ b/Formula/prince.rb
@@ -2,8 +2,8 @@ require "formula"
 
 class Prince < Formula
   homepage "http://www.princexml.com/"
-  url "https://www.princexml.com/download/prince-12.4-macosx.tar.gz"
-  sha256 "7f8abe72b88468c36f41754f9fd7f17821cef0c7f8d7e83f861b39b8bf393597"
+  url "https://www.princexml.com/download/prince-12.5-macosx.tar.gz"
+  sha256 "d7940c2f60b1e9657db1deb1144b2496cc34c728f650c36b24d6885b964e9aed"
 
   patch :DATA
 


### PR DESCRIPTION
https://www.princexml.com/releases/12/

# Prince 12.5 - April 2019

 - Explicitly tag headers and footers as pagination artifacts for all tagged PDFs, not just those in the PDF/UA-1 profile.
 - Fixed an issue where PDF/A validators might not have recognised rdf:resource attributes.
 - Fixed issues relating to images of unusual size.
 - Fixed a bug where the --pdf-xmp option did not work correctly when used through the control interface.
 - Fixed an issue when Prince would claim internal error: no area.
 - Throw exception for JavaScript with too much recursion.
 - Fixed a bug where the JavaScript hash property of anchor elements is incorrectly percent-decoded and not prefixed with the # mark.
 - Fixed a bug in which a forced page break in a very tall fixed height block could cause Prince to hang.
 - Improved performance for very large CSS style sheets.